### PR TITLE
Set Rust to 1.46.0 for ex_keccak

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 erlang 23.0.3
 elixir 1.10.4-otp-23
+rust 1.46.0


### PR DESCRIPTION
lock `.tool-versions` to Rust 1.46.0