### PR TITLE
add applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule ExPlasma.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      applications: [],
+      applications: [:ex_abi, :ex_rlp, :ex_keccak, :ex_secp256k1, :merkle_tree],
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
if `ex_plasma` is used as a dependency its dependencies (merkle_tree etc) are not included to releases